### PR TITLE
ignore the new block editor

### DIFF
--- a/simple-mathjax.php
+++ b/simple-mathjax.php
@@ -14,7 +14,7 @@
 add_action('wp_head','configure_mathjax',1);
 function configure_mathjax() {
   $custom_config = wp_kses( get_option('custom_mathjax_config'), array() );
-  $config = $custom_config ? $custom_config : "MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\\\(','\\\\)']], processEscapes: true}});\n";
+  $config = $custom_config ? $custom_config : "MathJax.Hub.Config({tex2jax: {ignoreClass: 'tex2jax_ignore|editor-rich-text', inlineMath: [['$','$'], ['\\\\(','\\\\)']], processEscapes: true}});\n";
   echo "\n<script type='text/x-mathjax-config'>\n" . $config . "</script>\n";
 }
 


### PR DESCRIPTION
WordPress 5.0 introduces a fancy new editor, which MathJax doesn't know
to ignore. This commit adds 'editor-rich-text' to the ignoreClass
setting, so MathJax won't run on rich text blocks in the editor.

Sites with custom MathJax configs will need to add the following to
their tex2jax config:

    ignoreClass: 'tex2jax_ignore|editor-rich-text'